### PR TITLE
Add custom headers for token refresh

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -73,6 +73,9 @@ class Client extends http.BaseClient {
   /// The underlying HTTP client.
   http.Client _httpClient;
 
+  /// Custom headers for authorizing the client
+  final Map<String, String> customHeaders;
+
   /// Creates a new client from a pre-existing set of credentials.
   ///
   /// When authorizing a client for the first time, you should use
@@ -87,7 +90,8 @@ class Client extends http.BaseClient {
       {this.identifier,
       this.secret,
       bool basicAuth = true,
-      http.Client httpClient})
+      http.Client httpClient,
+      this.customHeaders = const {}})
       : _basicAuth = basicAuth,
         _httpClient = httpClient == null ? new http.Client() : httpClient {
     if (identifier == null && secret != null) {
@@ -154,7 +158,8 @@ class Client extends http.BaseClient {
         secret: secret,
         newScopes: newScopes,
         basicAuth: _basicAuth,
-        httpClient: _httpClient);
+        httpClient: _httpClient,
+        customHeaders: customHeaders);
 
     return this;
   }

--- a/lib/src/credentials.dart
+++ b/lib/src/credentials.dart
@@ -191,7 +191,8 @@ class Credentials {
       String secret,
       Iterable<String> newScopes,
       bool basicAuth = true,
-      http.Client httpClient}) async {
+      http.Client httpClient,
+      Map<String, String> customHeaders = const {}}) async {
     var scopes = this.scopes;
     if (newScopes != null) scopes = newScopes.toList();
     if (scopes == null) scopes = [];
@@ -211,6 +212,7 @@ class Credentials {
     }
 
     var headers = <String, String>{};
+    headers.addAll(customHeaders);
 
     var body = {"grant_type": "refresh_token", "refresh_token": refreshToken};
     if (scopes.isNotEmpty) body["scope"] = scopes.join(_delimiter);

--- a/lib/src/resource_owner_password_grant.dart
+++ b/lib/src/resource_owner_password_grant.dart
@@ -85,5 +85,9 @@ Future<Client> resourceOwnerPasswordGrant(
       response, authorizationEndpoint, startTime, scopes, delimiter,
       getParameters: getParameters);
   return new Client(credentials,
-      identifier: identifier, secret: secret, httpClient: httpClient, basicAuth: basicAuth);
+      identifier: identifier,
+      secret: secret,
+      httpClient: httpClient,
+      basicAuth: basicAuth,
+      customHeaders: headers);
 }

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -83,15 +83,22 @@ void main() {
       expect(client.read(requestUri), completion(equals('good job')));
     });
 
-    test("can manually refresh the credentials", () async {
+    test(
+        "can manually refresh the credentials and uses custom headers if provided",
+        () async {
       var credentials = new oauth2.Credentials('access token',
           refreshToken: 'refresh token', tokenEndpoint: tokenEndpoint);
       var client = new oauth2.Client(credentials,
-          identifier: 'identifier', secret: 'secret', httpClient: httpClient);
+          identifier: 'identifier',
+          secret: 'secret',
+          httpClient: httpClient,
+          customHeaders: {'x-api-key': 'myApiKey'});
 
       httpClient.expectRequest((request) {
         expect(request.method, equals('POST'));
         expect(request.url.toString(), equals(tokenEndpoint.toString()));
+        expect(request.headers, containsPair("x-api-key", "myApiKey"));
+
         return new Future.value(new http.Response(
             jsonEncode(
                 {'access_token': 'new access token', 'token_type': 'bearer'}),

--- a/test/credentials_test.dart
+++ b/test/credentials_test.dart
@@ -58,7 +58,9 @@ void main() {
         throwsStateError);
   });
 
-  test("can refresh with a refresh token and a token endpoint", () async {
+  test(
+      "can refresh with a refresh token and a token endpoint and uses custom headers if provided",
+      () async {
     var credentials = new oauth2.Credentials('access token',
         refreshToken: 'refresh token',
         tokenEndpoint: tokenEndpoint,
@@ -79,6 +81,7 @@ void main() {
           request.headers,
           containsPair("Authorization",
               "Basic aWQlQzMlQUJudCVDNCVBQmZpZXI6cyVDMyVBQmNyZXQ="));
+      expect(request.headers, containsPair("x-api-key", "myApiKey"));
 
       return new Future.value(new http.Response(
           jsonEncode({
@@ -91,7 +94,10 @@ void main() {
     });
 
     credentials = await credentials.refresh(
-        identifier: 'idëntīfier', secret: 'sëcret', httpClient: httpClient);
+        identifier: 'idëntīfier',
+        secret: 'sëcret',
+        httpClient: httpClient,
+        customHeaders: {'x-api-key': 'myApiKey'});
     expect(credentials.accessToken, equals('new access token'));
     expect(credentials.refreshToken, equals('new refresh token'));
   });


### PR DESCRIPTION
Adds the possibility to pass custom headers when obtaining credentials using a resource owner password grant.